### PR TITLE
fix(docs): dead links; add markdown link check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,5 +21,9 @@ jobs:
           node-version: '14'
       - name: Install markdownlint
         run: npm install -g markdownlint-cli
+      - name: Install markdownlint
+        run: npm install -g markdown-link-check
       - name: markdownlint
+        run: just lint-docs
+      - name: markdown-link-check
         run: just lint-docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,9 +21,9 @@ jobs:
           node-version: '14'
       - name: Install markdownlint
         run: npm install -g markdownlint-cli
-      - name: Install markdownlint
+      - name: Install markdown-link-check
         run: npm install -g markdown-link-check
       - name: markdownlint
         run: just lint-docs
       - name: markdown-link-check
-        run: just lint-docs
+        run: just linkcheck-docs

--- a/.markdownlinkcheck.json
+++ b/.markdownlinkcheck.json
@@ -1,0 +1,10 @@
+{
+    "ignorePatterns": [{
+        "pattern": "^https://try.digitalocean.com/freetrialoffer"
+    }],
+    "timeout": "5s",
+    "retryOn429": true,
+    "retryCount": 5,
+    "fallbackRetryDelay": "30s",
+    "aliveStatusCodes": [200, 206]
+}

--- a/crates/kubelet/src/mio_uds_windows/README.md
+++ b/crates/kubelet/src/mio_uds_windows/README.md
@@ -54,7 +54,7 @@ Support for Unix domain sockets was introduced in Windows 10
 
 ## License
 
-This project is licensed under MIT license ([LICENSE-MIT](LICENSE-MIT) or
+This project is licensed under MIT license ([LICENSE-MIT](LICENSE) or
 [http://opensource.org/licenses/MIT](http://opensource.org/licenses/MIT)).
 
 ## Contributing

--- a/demos/wasi/hello-world-assemblyscript/README.md
+++ b/demos/wasi/hello-world-assemblyscript/README.md
@@ -44,7 +44,7 @@ bindings provided in AssemblyScript.
 
 If you are interested in starting your own AssemblyScript project, visit the
 AssemblyScript
-[getting started guide](https://docs.assemblyscript.org/quick-start).
+[getting started guide](https://www.assemblyscript.org/).
 
 If you don't have Krustlet with the WASI provider running locally, see the
 instructions in the [tutorial](../../../docs/intro/tutorial03.md) for running

--- a/docs/howto/README.md
+++ b/docs/howto/README.md
@@ -14,8 +14,5 @@ quickly accomplish common tasks.
 - [Running Krustlet on any Kubernetes cluster with
   inlets](krustlet-with-inlets.md)
 - [Running Krustlet on MicroK8s](krustlet-on-microk8s.md)
-- [Running Kubernetes on Kubernetes-in-Docker (KinD)](kubernetes-on-kind.md)
-- [Running Kubernetes on Minikube](kubernetes-on-minikube.md)
-
 - [Running Web Assembly (WASM) workloads in Kubernetes](wasm.md)
 - [Registering a CSI driver](csi.md)

--- a/docs/howto/README.md
+++ b/docs/howto/README.md
@@ -14,8 +14,6 @@ quickly accomplish common tasks.
 - [Running Krustlet on any Kubernetes cluster with
   inlets](krustlet-with-inlets.md)
 - [Running Krustlet on MicroK8s](krustlet-on-microk8s.md)
-- [Running Kubernetes on Amazon Elastic Kubernetes Service
-  (EKS)](kubernetes-on-eks.md)
 - [Running Kubernetes on Kubernetes-in-Docker (KinD)](kubernetes-on-kind.md)
 - [Running Kubernetes on Minikube](kubernetes-on-minikube.md)
 

--- a/docs/howto/kubernetes-on-minikube.md
+++ b/docs/howto/kubernetes-on-minikube.md
@@ -5,7 +5,7 @@ This tutorial will focus on using a tool called
 
 If you haven't installed them already, go ahead and [install VirtualBox 5.2 or
 higher](https://www.virtualbox.org/), [install
-minikube](https://minikube.sigs.k8s.io/docs/start/linux/), and [install
+minikube](https://minikube.sigs.k8s.io/docs/start/), and [install
 kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 
 You'll need `kubectl` to interact with the cluster once it's created.

--- a/docs/intro/quickstart.md
+++ b/docs/intro/quickstart.md
@@ -20,7 +20,7 @@ install Krustlet on your own Kubernetes cluster.
 For production use:
 
 - [Azure](../howto/krustlet-on-azure.md)
-- [Amazon Elastic Kubernetes Service (EKS)](../howto/kubernetes-on-eks.md)
+- [Amazon Elastic Kubernetes Service (EKS)](../howto/krustlet-on-eks.md)
 
 For development and evaluation purposes, it may make sense to use a VM-based
 Kubernetes cluster for quick and easy setup and teardown:

--- a/justfile
+++ b/justfile
@@ -14,6 +14,9 @@ build +FLAGS='':
 lint-docs:
     markdownlint '**/*.md' -c .markdownlint.json
 
+linkcheck-docs:
+    find . -name \*.md | xargs -I{} markdown-link-check -c .markdownlinkcheck.json {} 
+
 test:
     cargo fmt --all -- --check
     cargo clippy --workspace


### PR DESCRIPTION
digitaloceans trial site worked manually in my browser, but it didn't seem to like the crawler. Maybe a useragent issue of some kind? 