### PR TITLE
Fix OCI errors

### DIFF
--- a/crates/oci-distribution/src/errors.rs
+++ b/crates/oci-distribution/src/errors.rs
@@ -66,6 +66,8 @@ pub enum OciErrorCode {
     /// This error is returned when the manifest, identified by name and tag is unknown to the repository.
     ManifestUnknown,
     /// Manifest failed signature validation
+    ///
+    /// DEPRECATED: This error code has been removed from the OCI spec.
     ManifestUnverified,
     /// Invalid repository name
     NameInvalid,
@@ -74,6 +76,8 @@ pub enum OciErrorCode {
     /// Provided length did not match content length
     SizeInvalid,
     /// Manifest tag did not match URI
+    ///
+    /// DEPRECATED: This error code has been removed from the OCI spec.
     TagInvalid,
     /// Authentication required.
     Unauthorized,

--- a/crates/oci-distribution/src/errors.rs
+++ b/crates/oci-distribution/src/errors.rs
@@ -81,6 +81,8 @@ pub enum OciErrorCode {
     Denied,
     /// This operation is unsupported
     Unsupported,
+    /// Too many requests from client
+    Toomanyrequests,
 }
 
 #[cfg(test)]

--- a/crates/oci-distribution/src/errors.rs
+++ b/crates/oci-distribution/src/errors.rs
@@ -106,6 +106,19 @@ mod test {
         assert_ne!(serde_json::value::Value::Null, e.detail);
     }
 
+    const EXAMPLE_ERROR_TOOMANYREQUESTS: &str = r#"
+      {"errors":[{"code":"TOOMANYREQUESTS","message":"pull request limit exceeded","detail":"You have reached your pull rate limit."}]}
+      "#;
+    #[test]
+    fn test_deserialize_toomanyrequests() {
+        let envelope: OciEnvelope =
+            serde_json::from_str(EXAMPLE_ERROR_TOOMANYREQUESTS).expect("parse example error");
+        let e = &envelope.errors[0];
+        assert_eq!(OciErrorCode::Toomanyrequests, e.code);
+        assert_eq!("pull request limit exceeded", e.message);
+        assert_ne!(serde_json::value::Value::Null, e.detail);
+    }
+
     const EXAMPLE_ERROR_MISSING_MESSAGE: &str = r#"
       {"errors":[{"code":"UNAUTHORIZED","detail":[{"Type":"repository","Name":"hello-wasm","Action":"pull"}]}]}
       "#;


### PR DESCRIPTION
## Changes

OCI errors were updated to be even with [the spec](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#errors-2):
* ~~`TAG_INVALID` and `MANIFEST_UNVERIFIED` were removed from OCI spec: https://github.com/opencontainers/distribution-spec/pull/206~~
* `TOOMANYREQUESTS` was added

Tested on CentOS 8.2.2004 and KinD with Kubernetes v1.21.1.

## Why?

After bootstrapping a krustlet-wasi node I received this error:

> Jul 17 18:02:33.250 ERROR kubelet::state::common::image_pull: error=error decoding response body: unknown variant `TOOMANYREQUESTS`, expected one of `BLOB_UNKNOWN`, `BLOB_UPLOAD_INVALID`, `BLOB_UPLOAD_UNKNOWN`, `DIGEST_INVALID`, `MANIFEST_BLOB_UNKNOWN`, `MANIFEST_INVALID`, `MANIFEST_UNKNOWN`, `MANIFEST_UNVERIFIED`, `NAME_INVALID`, `NAME_UNKNOWN`, `SIZE_INVALID`, `UNAUTHORIZED`, `DENIED`, `UNSUPPORTED`, `TOO_MANY_REQUESTS` at line 4 column 31

and after that more conveniently:

> Jul 17 18:05:44.213 ERROR kubelet::state::common::image_pull: error=OCI API error: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit on https://registry-1.docker.io/v2/kindest/kindnetd/manifests/v20210326-1e038dc5