### PR TITLE
fix: node selector for greet demo

### DIFF
--- a/demos/wasi/greet/greet-wasi.yaml
+++ b/demos/wasi/greet/greet-wasi.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     app: greet
 spec:
+  nodeSelector:
+    kubernetes.io/arch: "wasm32-wasi"
   containers:
     - image: webassembly.azurecr.io/hello-wasm:v1
       imagePullPolicy: Always


### PR DESCRIPTION
it's missing the arch selector present on the other manifests, so it doesn't always hit Krustlet nodes