### PR TITLE
chore(*): Updates docs now that we are in CNCF

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,11 +2,12 @@
 
 This document describes the requirements for committing to this repository.
 
-## Contributor License Agreement
+## Developer Certificate of Origin (DCO)
 
-This repository is governed under a [Contributor License
-Agreement](https://cla.opensource.microsoft.com/deislabs/krustlet). All PR
-submitters must accept the CLA before their contributions can be merged.
+In order to contribute to this project, you must sign each of your commits to
+attest that you have the right to contribute that code. This is done with the
+`-s`/`--signoff` flag on `git commit`. More information about DCO can be found
+[here](https://developercertificate.org/)
 
 ## Pull Request Management
 
@@ -23,10 +24,5 @@ satisfy the above requirement.
 
 ## Code of Conduct
 
-This project has adopted the
-[Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the
-[Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
-or contact
-[opencode@microsoft.com](mailto:opencode@microsoft.com)
-with any additional questions or comments.
+This project has adopted the [CNCF Code of
+Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
   same "printed page" as the copyright notice for easier
   identification within third-party archives.
 
-Copyright (c) Microsoft Corporation. All Rights Reserved.
+Copyright (c) The Krustlet Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -31,10 +31,5 @@ You can reach the Krustlet community and developers via the following channels:
 
 ## Code of Conduct
 
-This project has adopted the [Microsoft Open Source Code of
-Conduct](https://opensource.microsoft.com/codeofconduct/).
-
-For more information see the [Code of Conduct
-FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact
-[opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional
-questions or comments.
+This project has adopted the [CNCF Code of
+Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).

--- a/docs/community/code-of-conduct.md
+++ b/docs/community/code-of-conduct.md
@@ -1,9 +1,4 @@
 # Code of Conduct
 
-This project has adopted the [Microsoft Open Source Code of
-Conduct](https://opensource.microsoft.com/codeofconduct/).
-
-For more information see the [Code of Conduct
-FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact
-[opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional
-questions or comments.
+This project has adopted the [CNCF Code of
+Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).

--- a/docs/community/developers.md
+++ b/docs/community/developers.md
@@ -11,6 +11,10 @@ To build krustlet, you will need
 - openssl (Or use the [`rustls-tls`](#building-without-openssl) feature)
 - git
 
+Due to this being a relatively bleeding edge project, we don't have any
+guarantees around MSRV (minimum supported Rust version). Currently, building
+requires rust 1.53.0+
+
 If you want to test krustlet, you will also require
 
 - A Kubernetes cluster


### PR DESCRIPTION
Namely, this updates the copyright to "The Krustlet Authors" now that
things have been transferred to the CNCF. Also adds some clarification
around MSRV as the most recent updates to `kube` use a new feature only
available after 1.53