### PR TITLE
Added license property to Cargo.toml to specify Apache License 2.0

### DIFF
--- a/crates/wasi-provider/Cargo.toml
+++ b/crates/wasi-provider/Cargo.toml
@@ -10,6 +10,7 @@ authors = [
   "Kevin Flansburg <kevin.flansburg@gmail.com>",
 ]
 edition = "2018"
+license = "Apache-2.0"
 name = "wasi-provider"
 publish = false
 version = "1.0.0-alpha.1"


### PR DESCRIPTION
fixes #654 

Signed-off-by: Sönke Liebau <soenke.liebau@gmail.com>