### PR TITLE
chore(*): Address `cargo deny` failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,15 +1264,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
@@ -1328,15 +1319,15 @@ dependencies = [
 
 [[package]]
 name = "k8s-csi"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e7390e757d64e9b894e2ccdcfe11774680c5161d94908b6ff4ded0ccb2eeec"
+checksum = "5494bb53430a090bdcfa2677b0c5f19989a3c0cc43e2660f2e0f7d099218ade7"
 dependencies = [
- "prost 0.7.0",
- "prost-build 0.7.0",
- "prost-types 0.7.0",
- "tonic 0.4.3",
- "tonic-build 0.4.2",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]
@@ -1422,7 +1413,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio 1.9.0",
- "tonic 0.5.0",
+ "tonic",
  "tracing-subscriber",
  "wasi-provider",
 ]
@@ -1535,8 +1526,8 @@ dependencies = [
  "miow 0.2.2",
  "notify",
  "oci-distribution",
- "prost 0.8.0",
- "prost-types 0.8.0",
+ "prost",
+ "prost-types",
  "rcgen",
  "regex",
  "remove_dir_all 0.7.0",
@@ -1552,8 +1543,8 @@ dependencies = [
  "tokio 1.9.0",
  "tokio-compat-02",
  "tokio-stream",
- "tonic 0.5.0",
- "tonic-build 0.5.1",
+ "tonic",
+ "tonic-build",
  "tower",
  "tower-test",
  "tracing",
@@ -2172,40 +2163,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
-dependencies = [
- "bytes 1.0.1",
- "prost-derive 0.7.0",
-]
-
-[[package]]
-name = "prost"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes 1.0.1",
- "prost-derive 0.8.0",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
-dependencies = [
- "bytes 1.0.1",
- "heck",
- "itertools 0.9.0",
- "log 0.4.14",
- "multimap",
- "petgraph",
- "prost 0.7.0",
- "prost-types 0.7.0",
- "tempfile",
- "which",
+ "prost-derive",
 ]
 
 [[package]]
@@ -2220,23 +2183,10 @@ dependencies = [
  "log 0.4.14",
  "multimap",
  "petgraph",
- "prost 0.8.0",
- "prost-types 0.8.0",
+ "prost",
+ "prost-types",
  "tempfile",
  "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
-dependencies = [
- "anyhow",
- "itertools 0.9.0",
- "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.74",
 ]
 
 [[package]]
@@ -2254,22 +2204,12 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
-dependencies = [
- "bytes 1.0.1",
- "prost 0.7.0",
-]
-
-[[package]]
-name = "prost-types"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
  "bytes 1.0.1",
- "prost 0.8.0",
+ "prost",
 ]
 
 [[package]]
@@ -3358,36 +3298,6 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac42cd97ac6bd2339af5bcabf105540e21e45636ec6fa6aae5e85d44db31be0"
-dependencies = [
- "async-stream",
- "async-trait",
- "base64 0.13.0",
- "bytes 1.0.1",
- "futures-core",
- "futures-util",
- "h2",
- "http 0.2.4",
- "http-body",
- "hyper",
- "percent-encoding 2.1.0",
- "pin-project 1.0.8",
- "prost 0.7.0",
- "prost-derive 0.7.0",
- "tokio 1.9.0",
- "tokio-rustls",
- "tokio-stream",
- "tokio-util",
- "tower",
- "tower-service",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "tonic"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584f064fdfc50017ec39162d5aebce49912f1eb16fd128e04b7f4ce4907c7e5"
@@ -3405,9 +3315,10 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding 2.1.0",
  "pin-project 1.0.8",
- "prost 0.8.0",
- "prost-derive 0.8.0",
+ "prost",
+ "prost-derive",
  "tokio 1.9.0",
+ "tokio-rustls",
  "tokio-stream",
  "tokio-util",
  "tower",
@@ -3419,24 +3330,12 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c695de27302f4697191dda1c7178131a8cb805463dda02864acb80fe1322fdcf"
-dependencies = [
- "proc-macro2",
- "prost-build 0.7.0",
- "quote 1.0.9",
- "syn 1.0.74",
-]
-
-[[package]]
-name = "tonic-build"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d12faebbe071b06f486be82cc9318350814fdd07fcb28f3690840cd770599283"
 dependencies = [
  "proc-macro2",
- "prost-build 0.8.0",
+ "prost-build",
  "quote 1.0.9",
  "syn 1.0.74",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1332,11 +1332,11 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95e7390e757d64e9b894e2ccdcfe11774680c5161d94908b6ff4ded0ccb2eeec"
 dependencies = [
- "prost",
- "prost-build",
- "prost-types",
- "tonic",
- "tonic-build",
+ "prost 0.7.0",
+ "prost-build 0.7.0",
+ "prost-types 0.7.0",
+ "tonic 0.4.3",
+ "tonic-build 0.4.2",
 ]
 
 [[package]]
@@ -1422,7 +1422,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio 1.9.0",
- "tonic",
+ "tonic 0.5.0",
  "tracing-subscriber",
  "wasi-provider",
 ]
@@ -1535,8 +1535,8 @@ dependencies = [
  "miow 0.2.2",
  "notify",
  "oci-distribution",
- "prost",
- "prost-types",
+ "prost 0.8.0",
+ "prost-types 0.8.0",
  "rcgen",
  "regex",
  "remove_dir_all 0.7.0",
@@ -1552,8 +1552,8 @@ dependencies = [
  "tokio 1.9.0",
  "tokio-compat-02",
  "tokio-stream",
- "tonic",
- "tonic-build",
+ "tonic 0.5.0",
+ "tonic-build 0.5.1",
  "tower",
  "tower-test",
  "tracing",
@@ -2177,7 +2177,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
 dependencies = [
  "bytes 1.0.1",
- "prost-derive",
+ "prost-derive 0.7.0",
+]
+
+[[package]]
+name = "prost"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
+dependencies = [
+ "bytes 1.0.1",
+ "prost-derive 0.8.0",
 ]
 
 [[package]]
@@ -2192,8 +2202,26 @@ dependencies = [
  "log 0.4.14",
  "multimap",
  "petgraph",
- "prost",
- "prost-types",
+ "prost 0.7.0",
+ "prost-types 0.7.0",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
+dependencies = [
+ "bytes 1.0.1",
+ "heck",
+ "itertools 0.10.1",
+ "log 0.4.14",
+ "multimap",
+ "petgraph",
+ "prost 0.8.0",
+ "prost-types 0.8.0",
  "tempfile",
  "which",
 ]
@@ -2212,13 +2240,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.1",
+ "proc-macro2",
+ "quote 1.0.9",
+ "syn 1.0.74",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
 dependencies = [
  "bytes 1.0.1",
- "prost",
+ "prost 0.7.0",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
+dependencies = [
+ "bytes 1.0.1",
+ "prost 0.8.0",
 ]
 
 [[package]]
@@ -2525,14 +2576,14 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.6.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec448bc157977efdc0a71369cf923915b0c4806b1b2449c3fb011071d6f7c38"
+checksum = "2288c66aeafe3b2ed227c981f364f9968fa952ef0b30e84ada4486e7ee24d00a"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "proc-macro2",
  "quote 1.0.9",
- "rustc_version 0.2.3",
+ "rustc_version 0.4.0",
  "syn 1.0.74",
 ]
 
@@ -2547,15 +2598,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
 
 [[package]]
 name = "rustc_version"
@@ -2721,15 +2763,6 @@ checksum = "7e4effb91b4b8b6fb7732e670b6cee160278ff8e6bf485c7805d9e319d76e284"
 dependencies = [
  "core-foundation-sys",
  "libc",
-]
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser 0.7.0",
 ]
 
 [[package]]
@@ -3341,13 +3374,44 @@ dependencies = [
  "hyper",
  "percent-encoding 2.1.0",
  "pin-project 1.0.8",
- "prost",
- "prost-derive",
+ "prost 0.7.0",
+ "prost-derive 0.7.0",
  "tokio 1.9.0",
  "tokio-rustls",
  "tokio-stream",
  "tokio-util",
  "tower",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584f064fdfc50017ec39162d5aebce49912f1eb16fd128e04b7f4ce4907c7e5"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64 0.13.0",
+ "bytes 1.0.1",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.4",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding 2.1.0",
+ "pin-project 1.0.8",
+ "prost 0.8.0",
+ "prost-derive 0.8.0",
+ "tokio 1.9.0",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tower-layer",
  "tower-service",
  "tracing",
  "tracing-futures",
@@ -3360,7 +3424,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c695de27302f4697191dda1c7178131a8cb805463dda02864acb80fe1322fdcf"
 dependencies = [
  "proc-macro2",
- "prost-build",
+ "prost-build 0.7.0",
+ "quote 1.0.9",
+ "syn 1.0.74",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d12faebbe071b06f486be82cc9318350814fdd07fcb28f3690840cd770599283"
+dependencies = [
+ "proc-macro2",
+ "prost-build 0.8.0",
  "quote 1.0.9",
  "syn 1.0.74",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 tempfile = "3.2"
 tokio = {version = "1.0", features = ["macros", "rt-multi-thread", "time", "process"]}
-tonic = "0.4"
+tonic = "0.5"
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ wasi-provider = {path = "./crates/wasi-provider", version = "1.0.0-alpha.1", def
 [dev-dependencies]
 async-trait = "0.1"
 compiletest_rs = "0.6"
-k8s-csi = "0.3"
+k8s-csi = "0.4"
 kube-runtime = {version = "0.58", default-features = false}
 reqwest = {version = "0.11", default-features = false}
 serde_derive = "1.0"

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -48,7 +48,7 @@ hostname = "0.3"
 http = "0.2"
 hyper = {version = "0.14", default-features = false, features = ["stream"]}
 json-patch = "0.2"
-k8s-csi = "0.3"
+k8s-csi = "0.4"
 k8s-openapi = {version = "0.12", default-features = false, features = ["v1_21", "api"]}
 krator = {version = "0.4", default-features = false}
 kube = {version = "0.58", default-features = false, features = ["jsonpatch"]}

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -56,8 +56,8 @@ kube-runtime = {version = "0.58", default-features = false}
 lazy_static = "1.4"
 notify = "5.0.0-pre.3"
 oci-distribution = {path = "../oci-distribution", version = "0.7", default-features = false}
-prost = "0.7"
-prost-types = "0.7"
+prost = "0.8"
+prost-types = "0.8"
 rcgen = "0.8"
 regex = "1.5"
 reqwest = {version = "0.11", default-features = false, features = ["json", "stream"]}
@@ -69,7 +69,7 @@ tempfile = "3.2"
 thiserror = "1.0"
 tokio = {version = "1.0", features = ["fs", "macros", "signal", "net"]}
 tokio-stream = {version = "0.1", features = ["fs", "net"]}
-tonic = "0.4"
+tonic = "0.5"
 tower = {version = "0.4.2", features = ["util"]}
 tracing = {version = "0.1", features = ["log"]}
 tracing-futures = "0.2"
@@ -101,7 +101,7 @@ tempfile = "3.1"
 tower-test = "0.4"
 
 [build-dependencies]
-tonic-build = "0.4"
+tonic-build = "0.5"
 
 [package.metadata.docs.rs]
 features = ["docs"]

--- a/crates/kubelet/src/grpc_sock/unix/mod.rs
+++ b/crates/kubelet/src/grpc_sock/unix/mod.rs
@@ -35,7 +35,16 @@ impl Stream for Socket {
     }
 }
 
-impl Connected for UnixStream {}
+#[derive(Clone, Debug)]
+pub struct ConnectionData {}
+
+impl Connected for UnixStream {
+    type ConnectInfo = ConnectionData;
+
+    fn connect_info(&self) -> Self::ConnectInfo {
+        ConnectionData {}
+    }
+}
 
 impl AsyncRead for UnixStream {
     fn poll_read(

--- a/crates/kubelet/src/grpc_sock/windows/mod.rs
+++ b/crates/kubelet/src/grpc_sock/windows/mod.rs
@@ -81,7 +81,16 @@ impl Stream for Socket {
     }
 }
 
-impl Connected for UnixStream {}
+#[derive(Clone, Debug)]
+pub struct ConnectionData {}
+
+impl Connected for UnixStream {
+    type ConnectInfo = ConnectionData;
+
+    fn connect_info(&self) -> Self::ConnectInfo {
+        ConnectionData {}
+    }
+}
 
 impl AsyncRead for UnixStream {
     fn poll_read(

--- a/crates/oci-distribution/Cargo.toml
+++ b/crates/oci-distribution/Cargo.toml
@@ -44,4 +44,4 @@ tracing = {version = "0.1", features = ['log']}
 www-authenticate = "0.3"
 
 [dev-dependencies]
-rstest = "0.6"
+rstest = "0.11"

--- a/deny.toml
+++ b/deny.toml
@@ -1,27 +1,31 @@
+[advisories]
+ignore = [
+    # We are using some deprecated versions to support Windows
+    "RUSTSEC-2020-0016"
+]
+
 [licenses]
 
 confidence-threshold = 1.0
 copyleft = "deny"
 
 unlicensed = "deny"
+allow-osi-fsf-free = "both"
+default = "deny"
 
 # List of explictly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
-    "Apache-2.0",
-    "Apache-2.0 WITH LLVM-exception",
-    "BSD-3-Clause",
-    "CC0-1.0",
-    "ISC",
     "LicenseRef-ring",
     "LicenseRef-webpki",
-    "MIT",
-    "Zlib"
+    "CC0-1.0",
+    "BSD-2-Clause",
 ]
 
 deny = [
-    "AGPL-3.0"
+    "AGPL-3.0",
+    "WTFPL",
 ]
 
 [[licenses.clarify]]
@@ -36,4 +40,56 @@ name = "webpki"
 expression = "LicenseRef-webpki"
 license-files = [
     { path = "LICENSE", hash = 0x001c7e6c },
+]
+
+[bans]
+skip = [
+    # Pretty much all of these are for duplicate versions
+
+    # Clap is using a lower version, so we can ignore it for now
+    { name = "ansi_term", version = "=0.11.0" },
+    # Currently there is an upper bound on later versions of hyperx that make it impossible to
+    # resolve dependencies. We need https://github.com/dekellum/hyperx/pull/34 merged in order to
+    # update the dependencies here
+    { name = "base64", version = "=0.10.1" },
+    { name = "bytes", version = "=0.4.12" },
+    { name = "http", version = "=0.1.21" },
+    { name = "percent-encoding", version = "=1.0.1" },
+
+    # Old bitflags comes from old dependency needed for Windows
+    { name = "bitflags", version = "=0.9.1" },
+    # Windows testing dep
+    { name = "bytes", version = "=0.3.0" },
+    # Windows dep
+    { name = "bytes", version = "=0.5.6" },
+
+    # Duplicate deps from kube dependencies
+    { name = "pin-project", version = "=0.4.28"},
+    { name = "pin-project-internal", version = "=0.4.28"},
+
+    # Used by tempfile in our tests
+    { name = "remove_dir_all", version = "=0.5.3"},
+
+    # We depend on www-authenticate, which depends on these older versions
+    { name = "unicase", version = "=1.4.2"},
+    { name = "version_check", version = "=0.1.5"},
+
+    # There appear to be several wasmtime-wasi dependencies that are out of sync. This skips those
+    # specific ones
+    { name = "wast", version = "=35.0.2" },
+]
+
+skip-tree = [
+    # Skip these windows specific crates that we know are using old versions, which trigger duplicates
+    { name = "mio", version = "^0.6" },
+    { name = "miow", version = "^0.2" },
+    { name = "tokio-compat-02", version = "=0.2.0"},
+    { name = "env_logger", version = "=0.4.3"},
+    { name = "version-sync", version = "^0.5"},
+
+    # Warp uses an older version of rand, we can ignore that version here
+    { name = "rand", version = "=0.7.3" },
+
+    # Earlier version used by some of the WASI stuff
+    { name = "rustc_version", version = "=0.3.3"},
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -19,6 +19,8 @@ default = "deny"
 allow = [
     "LicenseRef-ring",
     "LicenseRef-webpki",
+    "LicenseRef-krator",
+    "LicenseRef-krator-derive",
     "CC0-1.0",
     "BSD-2-Clause",
 ]
@@ -40,6 +42,21 @@ name = "webpki"
 expression = "LicenseRef-webpki"
 license-files = [
     { path = "LICENSE", hash = 0x001c7e6c },
+]
+
+# TODO: Remove these once we bump krustlet
+[[licenses.clarify]]
+name = "krator"
+expression = "LicenseRef-krator"
+license-files = [
+    { path = "LICENSE", hash = 0x62365415 },
+]
+
+[[licenses.clarify]]
+name = "krator-derive"
+expression = "LicenseRef-krator-derive"
+license-files = [
+    { path = "LICENSE", hash = 0x62365415 },
 ]
 
 [bans]

--- a/tests/csi/socket_server.rs
+++ b/tests/csi/socket_server.rs
@@ -60,7 +60,16 @@ impl Stream for Socket {
     }
 }
 
-impl Connected for UnixStream {}
+#[derive(Clone, Debug)]
+pub struct ConnectionData {}
+
+impl Connected for UnixStream {
+    type ConnectInfo = ConnectionData;
+
+    fn connect_info(&self) -> Self::ConnectInfo {
+        ConnectionData {}
+    }
+}
 
 impl AsyncRead for UnixStream {
     fn poll_read(


### PR DESCRIPTION
This addresses all warnings and failures from `cargo deny` as a follow
up to #641. It streamlines the allowed licenses for now. There are currently
some warnings that will be fixed once https://github.com/kflansburg/k8s-csi/pull/2 is merged.
There are also 2 license warnings remaining. Both of them are from krator and
will be fixed once there is a new version published to crates.io.