### PR TITLE
Do not fail if Docker-Content-Digest not given.

### DIFF
--- a/crates/oci-distribution/src/client.rs
+++ b/crates/oci-distribution/src/client.rs
@@ -955,7 +955,7 @@ fn digest_header_value(response: &reqwest::Response) -> anyhow::Result<String> {
     let headers = response.headers();
     let digest_header = headers.get("Docker-Content-Digest");
     match digest_header {
-        None => Err(anyhow::anyhow!("resgistry did not return a digest header")),
+        None => Ok(String::new()),
         Some(hv) => hv
             .to_str()
             .map(|s| s.to_string())


### PR DESCRIPTION
AWS ECR (public.ecr.aws), Red Hat (registry.redhat.io), and likely other
registries do not provide the `Docker-Content-Digest` header. As
discussed in https://github.com/krustlet/krustlet/issues/624, this
header is not required by the OCI
[Spec](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pull).