### PR TITLE
oci-distribution: fix push to JFrog (and ghcr.io)

### DIFF
--- a/crates/oci-distribution/src/client.rs
+++ b/crates/oci-distribution/src/client.rs
@@ -17,7 +17,7 @@ use futures_util::future;
 use futures_util::stream::StreamExt;
 use hyperx::header::Header;
 use reqwest::header::HeaderMap;
-use reqwest::RequestBuilder;
+use reqwest::{RequestBuilder, Url};
 use serde::Deserialize;
 use sha2::Digest;
 use std::collections::HashMap;
@@ -588,12 +588,12 @@ impl Client {
         image: &Reference,
         digest: &str,
     ) -> anyhow::Result<String> {
-        let url = format!("{}&digest={}", location, digest);
+        let url = Url::parse_with_params(location, &[("digest", digest)])?;
         let mut close_headers = HeaderMap::new();
         close_headers.insert("Content-Length", "0".parse().unwrap());
 
         let res = self
-            .apply_auth(self.client.put(&url), image, Some(close_headers))
+            .apply_auth(self.client.put(url), image, Some(close_headers))
             .send()
             .await?;
         self.extract_location_header(&image, res, &reqwest::StatusCode::CREATED)


### PR DESCRIPTION
Supersedes: https://github.com/krustlet/krustlet/pull/617

There are several relevant commits:

- https://github.com/krustlet/krustlet/pull/670/commits/6769e723e2217dd3000c6a32286cedec09e5d58e: this is a fix for servers that are strict about the first query argument on the URI. JFrog is strict as GitHub registry in this sense, and they reject a request of the form `uri&query=`. They expect `uri?query1=<value>&query2=<value>`.

- https://github.com/krustlet/krustlet/pull/670/commits/b64f3e389ed825b83b0a6762450832b214065e58: building block for the next commit. This exposes a `RequestBuilderWrapper` type that can be used to initialize from a client, with a certain operation on it, and that allows to execute modifier functions that might need client information. When done, this type can be converted to a regular `RequestBuilder`, where further operations can be performed, and eventually, issue the request. This is a way for easily extendable operations on the `RequestBuilderWrapper` because those operations are composable.

- https://github.com/krustlet/krustlet/pull/670/commits/e8fb47aabe427ce68824ecb62e527e4204b81132: this is fixing https://github.com/kubewarden/kwctl/issues/59. If the server is strict, if an `Accept` header is sent, and it knows beforehand that this operation won't generate an object at all, or of any of the given MIME types in the `Accept` header, it can return a 406 Not Acceptable response, as JFrog is doing in this case.

All this being said: this PR is **not** fully fixing pushing to JFrog because it is not compliant with https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pushing-manifests. When pushing the manifest JFrog is not returning a `Location` header, but this is not on the `oci-distribution` plate. I'm going to report that to the JFrog team.