### PR TITLE
Make CSRs compatible with Kubernetes v1.22

### DIFF
--- a/crates/kubelet/src/bootstrapping/mod.rs
+++ b/crates/kubelet/src/bootstrapping/mod.rs
@@ -1,7 +1,7 @@
 use std::{convert::TryFrom, env, io, path::Path, str};
 
 use futures::{StreamExt, TryStreamExt};
-use k8s_openapi::api::certificates::v1beta1::CertificateSigningRequest;
+use k8s_openapi::api::certificates::v1::CertificateSigningRequest;
 use kube::api::{Api, ListParams, PostParams};
 use kube::config::Kubeconfig;
 use kube::Config;
@@ -86,7 +86,7 @@ async fn bootstrap_auth<K: AsRef<Path>>(
         trace!(csr_name = %config.node_name, "Generating and sending CSR to Kubernetes API");
         let csrs: Api<CertificateSigningRequest> = Api::all(client);
         let csr_json = serde_json::json!({
-          "apiVersion": "certificates.k8s.io/v1beta1",
+          "apiVersion": "certificates.k8s.io/v1",
           "kind": "CertificateSigningRequest",
           "metadata": {
             "name": config.node_name,
@@ -201,7 +201,7 @@ async fn bootstrap_tls(
     let client = kube::Client::try_from(kubeconfig)?;
     let csrs: Api<CertificateSigningRequest> = Api::all(client);
     let csr_json = serde_json::json!({
-        "apiVersion": "certificates.k8s.io/v1beta1",
+        "apiVersion": "certificates.k8s.io/v1",
         "kind": "CertificateSigningRequest",
         "metadata": {
             "name": csr_name,


### PR DESCRIPTION
The `certificates.k8s.io/v1beta1` API version of `CertificateSigningRequest` is no longer served as of Kubernetes v1.22. The `certificates.k8s.io/v1` API version is used instead which is available since v1.19.

The requirements of the new API version were already met:
> Notable changes in certificates.k8s.io/v1:
> * For API clients requesting certificates:
>   * `spec.signerName` is now required (see known [Kubernetes signers](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/#kubernetes-signers)), and requests for `kubernetes.io/legacy-unknown` are not allowed to be created via the `certificates.k8s.io/v1` API
>   * `spec.usages` is now required, may not contain duplicate values, and must only contain known usages
>
> see https://kubernetes.io/docs/reference/using-api/deprecation-guide/#certificatesigningrequest-v122

This change makes kubelet incompatible with Kubernetes v1.18 and lower.

`k8s-openapi` is currently compiled with the feature `v1_21` which is okay because the new API is available since `v1_19`.