### PR TITLE
Enable Device Plugin Volume Mounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3831,6 +3831,7 @@ dependencies = [
  "cap-std",
  "chrono",
  "futures",
+ "k8s-openapi",
  "krator",
  "kube",
  "kubelet",

--- a/crates/kubelet/src/volume/mod.rs
+++ b/crates/kubelet/src/volume/mod.rs
@@ -38,6 +38,8 @@ pub enum VolumeRef {
     Secret(SecretVolume),
     /// PVC volume
     PersistentVolumeClaim(PvcVolume),
+    /// Volume specified by a device plugin
+    DeviceVolume(HostPathVolume, PathBuf),
     /// hostpath volume
     HostPath(HostPathVolume),
     /// DownwardAPI volume
@@ -71,6 +73,7 @@ impl VolumeRef {
             VolumeRef::ConfigMap(cm) => cm.get_path(),
             VolumeRef::Secret(sec) => sec.get_path(),
             VolumeRef::PersistentVolumeClaim(pv) => pv.get_path(),
+            VolumeRef::DeviceVolume(host, _) => host.get_path(),
             VolumeRef::HostPath(host) => host.get_path(),
             VolumeRef::DownwardApi(d) => d.get_path(),
             VolumeRef::Projected(p) => p.get_path(),
@@ -83,6 +86,7 @@ impl VolumeRef {
             VolumeRef::ConfigMap(cm) => cm.mount(path).await,
             VolumeRef::Secret(sec) => sec.mount(path).await,
             VolumeRef::PersistentVolumeClaim(pv) => pv.mount(path).await,
+            VolumeRef::DeviceVolume(host, _) => host.mount().await,
             VolumeRef::HostPath(host) => host.mount().await,
             VolumeRef::DownwardApi(d) => d.mount(path).await,
             // We need to clone the path here so we are sure that it is owned since this mount call
@@ -97,6 +101,7 @@ impl VolumeRef {
             VolumeRef::ConfigMap(cm) => cm.unmount().await,
             VolumeRef::Secret(sec) => sec.unmount().await,
             VolumeRef::PersistentVolumeClaim(pv) => pv.unmount().await,
+            VolumeRef::DeviceVolume(_, _) => Ok(()),
             // Doesn't need any unmounting steps
             VolumeRef::HostPath(_) => Ok(()),
             VolumeRef::DownwardApi(d) => d.unmount().await,

--- a/crates/wasi-provider/Cargo.toml
+++ b/crates/wasi-provider/Cargo.toml
@@ -44,4 +44,5 @@ wat = "1.0.38"
 wasi-experimental-http-wasmtime = "0.5.0"
 
 [dev-dependencies]
+k8s-openapi = {version = "0.12", default-features = false, features = ["v1_21", "api"]}
 oci-distribution = {path = "../oci-distribution", version = "0.7"}

--- a/crates/wasi-provider/src/states/pod.rs
+++ b/crates/wasi-provider/src/states/pod.rs
@@ -80,9 +80,10 @@ impl GenericPodState for PodState {
         let mut run_context = self.run_context.write().await;
         run_context.modules = modules;
     }
+    // For this provider, set_volumes extends the current volumes rather than re-assigning
     async fn set_volumes(&mut self, volumes: HashMap<String, kubelet::volume::VolumeRef>) {
         let mut run_context = self.run_context.write().await;
-        run_context.volumes = volumes;
+        run_context.volumes.extend(volumes);
     }
     async fn backoff(&mut self, sequence: BackoffSequence) {
         let backoff_strategy = match sequence {


### PR DESCRIPTION
Currently, the piping is not in place for mounts specified by device plugins to be set in Pods. Nor is there support for mounting a host path at a specific container path.

This adds a new type of `VolumeRef` called `DeviceVolume` for specifying mounting a host path volume at a specific container path, as requested by a device plugin. It also modifies the WASI provider to enable appending volumes during the `Resources` state. 