### PR TITLE
Switched VolumeRef to non_exhaustive

### DIFF
--- a/crates/kubelet/src/volume/mod.rs
+++ b/crates/kubelet/src/volume/mod.rs
@@ -31,6 +31,7 @@ pub use secret::SecretVolume;
 /// alongside a pod handle as a way to manage the lifecycle of a Pod's volume. Each embedded type
 /// can be used separately as well
 #[allow(clippy::large_enum_variant)]
+#[non_exhaustive]
 pub enum VolumeRef {
     /// configmap volume
     ConfigMap(ConfigMapVolume),


### PR DESCRIPTION
This turns out to be trivial because the enum is never used exhaustively in core Krustlet code except in the context in which the compiler allows.

Closes #673

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>