### PR TITLE
Update k8s-openapi to 0.13 and k8s 1.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,8 +1375,9 @@ dependencies = [
 
 [[package]]
 name = "krator"
-version = "0.4.0"
-source = "git+https://github.com/thomastaylor312/krator?branch=chore/k8s_openapi#3229d4396824932b6708919bfb2ea38089797f6e"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668edc5ad3e89a2ad4c74c62de5c0c7790c146639f5697ce622c2b8ca086d08c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1395,8 +1396,9 @@ dependencies = [
 
 [[package]]
 name = "krator-derive"
-version = "0.3.0"
-source = "git+https://github.com/thomastaylor312/krator?branch=chore/k8s_openapi#3229d4396824932b6708919bfb2ea38089797f6e"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fa674a23c40b90b24a035eef7db57622b8012a6d22725f7f777c28ce91106d7"
 dependencies = [
  "proc-macro2",
  "quote 1.0.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,9 +1348,9 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbff78f6da26dde0d74188966d23fc763431d730d0f766ecf7699209f8fc243c"
+checksum = "748acc444200aa3528dc131a8048e131a9e75a611a52d152e276e99199313d1a"
 dependencies = [
  "base64 0.13.0",
  "bytes 1.0.1",
@@ -1376,8 +1376,7 @@ dependencies = [
 [[package]]
 name = "krator"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb71112409f9b1fe9f2bb6d6a57e679c8c20d8feb186b2485b47842e2874d1a1"
+source = "git+https://github.com/thomastaylor312/krator?branch=chore/k8s_openapi#3229d4396824932b6708919bfb2ea38089797f6e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1397,8 +1396,7 @@ dependencies = [
 [[package]]
 name = "krator-derive"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40288f982cf9b76b3784d652f509557a22fa454a070fd4e79fd9c13673a11066"
+source = "git+https://github.com/thomastaylor312/krator?branch=chore/k8s_openapi#3229d4396824932b6708919bfb2ea38089797f6e"
 dependencies = [
  "proc-macro2",
  "quote 1.0.9",
@@ -1440,9 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.58.1"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d3c79fb97a822a63ce9422f7302484748032c808954898ba248705e99ea110"
+checksum = "a0ae4dcb1a65182551922303a2d292b463513a6727db5ad980afbd32df7f3c16"
 dependencies = [
  "base64 0.13.0",
  "bytes 1.0.1",
@@ -1479,14 +1477,15 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.58.1"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbce0d890efc42abb31e974419e25a643a97ab7c6b3b9498bda686d10b55f8d"
+checksum = "04ccd59635e9b21353da8d4a394bb5d3473b5965ed44496c8f857281b0625ffe"
 dependencies = [
  "form_urlencoded",
  "http 0.2.4",
  "json-patch",
  "k8s-openapi",
+ "once_cell",
  "serde",
  "serde_json",
  "thiserror",
@@ -1494,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.58.1"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4f034d330a0849e1603e285389e3f0ed93b9a86017d46e851c9e49e6d0b99e2"
+checksum = "eec378b03890f9f2bfa9448a51aa0f6a4299f6bb2ed0d180330e628c7a395918"
 dependencies = [
  "dashmap",
  "derivative",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ dirs = {package = "dirs-next", version = "2.0.0"}
 futures = "0.3"
 hostname = "0.3"
 k8s-openapi = {version = "0.13", default-features = false, features = ["v1_22"]}
-krator = {version = "0.4", default-features = false, git = "https://github.com/thomastaylor312/krator", branch = "chore/k8s_openapi"}
+krator = {version = "0.5", default-features = false}
 kube = {version = "0.60", default-features = false}
 kubelet = {path = "./crates/kubelet", version = "1.0.0-alpha.1", default-features = false, features = ["cli"]}
 oci-distribution = {path = "./crates/oci-distribution", version = "0.7", default-features = false}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,9 @@ anyhow = "1.0"
 dirs = {package = "dirs-next", version = "2.0.0"}
 futures = "0.3"
 hostname = "0.3"
-k8s-openapi = {version = "0.12", default-features = false, features = ["v1_21"]}
-krator = {version = "0.4", default-features = false}
-kube = {version = "0.58", default-features = false}
+k8s-openapi = {version = "0.13", default-features = false, features = ["v1_22"]}
+krator = {version = "0.4", default-features = false, git = "https://github.com/thomastaylor312/krator", branch = "chore/k8s_openapi"}
+kube = {version = "0.60", default-features = false}
 kubelet = {path = "./crates/kubelet", version = "1.0.0-alpha.1", default-features = false, features = ["cli"]}
 oci-distribution = {path = "./crates/oci-distribution", version = "0.7", default-features = false}
 regex = "1.3"
@@ -61,7 +61,7 @@ wasi-provider = {path = "./crates/wasi-provider", version = "1.0.0-alpha.1", def
 async-trait = "0.1"
 compiletest_rs = "0.6"
 k8s-csi = "0.4"
-kube-runtime = {version = "0.58", default-features = false}
+kube-runtime = {version = "0.60", default-features = false}
 reqwest = {version = "0.11", default-features = false}
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -49,10 +49,10 @@ http = "0.2"
 hyper = {version = "0.14", default-features = false, features = ["stream"]}
 json-patch = "0.2"
 k8s-csi = "0.4"
-k8s-openapi = {version = "0.12", default-features = false, features = ["v1_21", "api"]}
-krator = {version = "0.4", default-features = false}
-kube = {version = "0.58", default-features = false, features = ["jsonpatch"]}
-kube-runtime = {version = "0.58", default-features = false}
+k8s-openapi = {version = "0.13", default-features = false, features = ["v1_22", "api"]}
+krator = {version = "0.4", default-features = false, git = "https://github.com/thomastaylor312/krator", branch = "chore/k8s_openapi"}
+kube = {version = "0.60", default-features = false, features = ["jsonpatch"]}
+kube-runtime = {version = "0.60", default-features = false}
 lazy_static = "1.4"
 notify = "5.0.0-pre.3"
 oci-distribution = {path = "../oci-distribution", version = "0.7", default-features = false}

--- a/crates/kubelet/Cargo.toml
+++ b/crates/kubelet/Cargo.toml
@@ -50,7 +50,7 @@ hyper = {version = "0.14", default-features = false, features = ["stream"]}
 json-patch = "0.2"
 k8s-csi = "0.4"
 k8s-openapi = {version = "0.13", default-features = false, features = ["v1_22", "api"]}
-krator = {version = "0.4", default-features = false, git = "https://github.com/thomastaylor312/krator", branch = "chore/k8s_openapi"}
+krator = {version = "0.5", default-features = false}
 kube = {version = "0.60", default-features = false, features = ["jsonpatch"]}
 kube-runtime = {version = "0.60", default-features = false}
 lazy_static = "1.4"

--- a/crates/kubelet/src/bootstrapping/mod.rs
+++ b/crates/kubelet/src/bootstrapping/mod.rs
@@ -144,20 +144,18 @@ async fn bootstrap_auth<K: AsRef<Path>>(
             };
 
             if let Some(cert) = status.certificate {
-                if status
-                    .conditions
-                    .into_iter()
-                    .any(|c| c.type_.as_str() == APPROVED_TYPE)
-                {
-                    debug!("Certificate has been approved, generating kubeconfig");
-                    generated_kubeconfig = gen_kubeconfig(
-                        ca_data,
-                        server,
-                        cert,
-                        cert_bundle.serialize_private_key_pem(),
-                    )?;
-                    got_cert = true;
-                    break;
+                if let Some(v) = status.conditions {
+                    if v.into_iter().any(|c| c.type_.as_str() == APPROVED_TYPE) {
+                        debug!("Certificate has been approved, generating kubeconfig");
+                        generated_kubeconfig = gen_kubeconfig(
+                            ca_data,
+                            server,
+                            cert,
+                            cert_bundle.serialize_private_key_pem(),
+                        )?;
+                        got_cert = true;
+                        break;
+                    }
                 }
             }
 
@@ -261,15 +259,13 @@ async fn bootstrap_tls(
         };
 
         if let Some(cert) = status.certificate {
-            if status
-                .conditions
-                .into_iter()
-                .any(|c| c.type_.as_str() == APPROVED_TYPE)
-            {
-                debug!("Certificate has been approved, extracting cert from response");
-                certificate = std::str::from_utf8(&cert.0)?.to_owned();
-                got_cert = true;
-                break;
+            if let Some(v) = status.conditions {
+                if v.into_iter().any(|c| c.type_.as_str() == APPROVED_TYPE) {
+                    debug!("Certificate has been approved, extracting cert from response");
+                    certificate = std::str::from_utf8(&cert.0)?.to_owned();
+                    got_cert = true;
+                    break;
+                }
             }
         }
         info!(remaining = ?start.elapsed(), "Got modified event, but CSR for serving certs is not currently approved");

--- a/crates/kubelet/src/container/mod.rs
+++ b/crates/kubelet/src/container/mod.rs
@@ -138,23 +138,23 @@ impl Container {
     }
 
     /// Get arguments of container.
-    pub fn args(&self) -> &Option<Vec<String>> {
-        &self.0.args
+    pub fn args(&self) -> Option<&Vec<String>> {
+        self.0.args.as_ref()
     }
 
     /// Get command of container.
-    pub fn command(&self) -> &Option<Vec<String>> {
-        &self.0.command
+    pub fn command(&self) -> Option<&Vec<String>> {
+        self.0.command.as_ref()
     }
 
     /// Get environment of container.
-    pub fn env(&self) -> &Option<Vec<k8s_openapi::api::core::v1::EnvVar>> {
-        &self.0.env
+    pub fn env(&self) -> Option<&Vec<k8s_openapi::api::core::v1::EnvVar>> {
+        self.0.env.as_ref()
     }
 
     /// Get environment of container.
-    pub fn env_from(&self) -> &Option<Vec<k8s_openapi::api::core::v1::EnvFromSource>> {
-        &self.0.env_from
+    pub fn env_from(&self) -> Option<&Vec<k8s_openapi::api::core::v1::EnvFromSource>> {
+        self.0.env_from.as_ref()
     }
 
     /// Get image of container as `oci_distribution::Reference`.
@@ -186,8 +186,8 @@ impl Container {
     }
 
     /// Get ports of container.
-    pub fn ports(&self) -> &Option<Vec<k8s_openapi::api::core::v1::ContainerPort>> {
-        &self.0.ports
+    pub fn ports(&self) -> Option<&Vec<k8s_openapi::api::core::v1::ContainerPort>> {
+        self.0.ports.as_ref()
     }
 
     /// Get readiness probe of container.
@@ -236,13 +236,13 @@ impl Container {
     }
 
     /// Get volume devices of container.
-    pub fn volume_devices(&self) -> &Option<Vec<k8s_openapi::api::core::v1::VolumeDevice>> {
-        &self.0.volume_devices
+    pub fn volume_devices(&self) -> Option<&Vec<k8s_openapi::api::core::v1::VolumeDevice>> {
+        self.0.volume_devices.as_ref()
     }
 
     /// Get volume mounts of container.
-    pub fn volume_mounts(&self) -> &Option<Vec<k8s_openapi::api::core::v1::VolumeMount>> {
-        &self.0.volume_mounts
+    pub fn volume_mounts(&self) -> Option<&Vec<k8s_openapi::api::core::v1::VolumeMount>> {
+        self.0.volume_mounts.as_ref()
     }
 
     /// Get working directory of container.

--- a/crates/kubelet/src/container/mod.rs
+++ b/crates/kubelet/src/container/mod.rs
@@ -138,22 +138,22 @@ impl Container {
     }
 
     /// Get arguments of container.
-    pub fn args(&self) -> &Vec<String> {
+    pub fn args(&self) -> &Option<Vec<String>> {
         &self.0.args
     }
 
     /// Get command of container.
-    pub fn command(&self) -> &Vec<String> {
+    pub fn command(&self) -> &Option<Vec<String>> {
         &self.0.command
     }
 
     /// Get environment of container.
-    pub fn env(&self) -> &Vec<k8s_openapi::api::core::v1::EnvVar> {
+    pub fn env(&self) -> &Option<Vec<k8s_openapi::api::core::v1::EnvVar>> {
         &self.0.env
     }
 
     /// Get environment of container.
-    pub fn env_from(&self) -> &Vec<k8s_openapi::api::core::v1::EnvFromSource> {
+    pub fn env_from(&self) -> &Option<Vec<k8s_openapi::api::core::v1::EnvFromSource>> {
         &self.0.env_from
     }
 
@@ -186,7 +186,7 @@ impl Container {
     }
 
     /// Get ports of container.
-    pub fn ports(&self) -> &Vec<k8s_openapi::api::core::v1::ContainerPort> {
+    pub fn ports(&self) -> &Option<Vec<k8s_openapi::api::core::v1::ContainerPort>> {
         &self.0.ports
     }
 
@@ -236,12 +236,12 @@ impl Container {
     }
 
     /// Get volume devices of container.
-    pub fn volume_devices(&self) -> &Vec<k8s_openapi::api::core::v1::VolumeDevice> {
+    pub fn volume_devices(&self) -> &Option<Vec<k8s_openapi::api::core::v1::VolumeDevice>> {
         &self.0.volume_devices
     }
 
     /// Get volume mounts of container.
-    pub fn volume_mounts(&self) -> &Vec<k8s_openapi::api::core::v1::VolumeMount> {
+    pub fn volume_mounts(&self) -> &Option<Vec<k8s_openapi::api::core::v1::VolumeMount>> {
         &self.0.volume_mounts
     }
 

--- a/crates/kubelet/src/kubelet.rs
+++ b/crates/kubelet/src/kubelet.rs
@@ -325,7 +325,7 @@ mod test {
     #[tokio::test]
     async fn test_env_vars() {
         let container = Container::new(&KubeContainer {
-            env: vec![
+            env: Some(vec![
                 EnvVar {
                     name: "first".into(),
                     value: Some("value".into()),
@@ -397,7 +397,7 @@ mod test {
                     }),
                     ..Default::default()
                 },
-            ],
+            ]),
             ..Default::default()
         });
         let name = "my-name".to_string();
@@ -408,8 +408,8 @@ mod test {
         annotations.insert("annotation".to_string(), "value".to_string());
         let pod = Pod::from(KubePod {
             metadata: ObjectMeta {
-                labels,
-                annotations,
+                labels: Some(labels),
+                annotations: Some(annotations),
                 name: Some(name),
                 namespace,
                 ..Default::default()

--- a/crates/kubelet/src/node/mod.rs
+++ b/crates/kubelet/src/node/mod.rs
@@ -655,14 +655,14 @@ impl Builder {
     pub fn build(self) -> Node {
         let metadata = k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta {
             name: Some(self.name),
-            annotations: self.annotations,
-            labels: self.labels,
+            annotations: Some(self.annotations),
+            labels: Some(self.labels),
             ..Default::default()
         };
 
         let spec = k8s_openapi::api::core::v1::NodeSpec {
             pod_cidr: Some(self.pod_cidr),
-            taints: self.taints,
+            taints: Some(self.taints),
             ..Default::default()
         };
 
@@ -677,15 +677,15 @@ impl Builder {
 
         let status = k8s_openapi::api::core::v1::NodeStatus {
             node_info: Some(node_info),
-            capacity: self.capacity,
-            allocatable: self.allocatable,
+            capacity: Some(self.capacity),
+            allocatable: Some(self.allocatable),
             daemon_endpoints: Some(k8s_openapi::api::core::v1::NodeDaemonEndpoints {
                 kubelet_endpoint: Some(k8s_openapi::api::core::v1::DaemonEndpoint {
                     port: self.port,
                 }),
             }),
-            conditions: self.conditions,
-            addresses: self.addresses,
+            conditions: Some(self.conditions),
+            addresses: Some(self.addresses),
             ..Default::default()
         };
 

--- a/crates/kubelet/src/pod/status.rs
+++ b/crates/kubelet/src/pod/status.rs
@@ -74,8 +74,16 @@ pub async fn initialize_pod_container_statuses(
                 .clone()
                 .unwrap_or_default();
 
-            let num_statuses = status.container_statuses.len();
-            let num_init_statuses = status.init_container_statuses.len();
+            let num_statuses = status
+                .container_statuses
+                .as_ref()
+                .map(|statuses| statuses.len())
+                .unwrap_or(0);
+            let num_init_statuses = status
+                .init_container_statuses
+                .as_ref()
+                .map(|statuses| statuses.len())
+                .unwrap_or(0);
 
             if (num_statuses == num_containers) && (num_init_statuses == num_init_containers) {
                 break 'main Ok(());

--- a/crates/kubelet/src/provider/mod.rs
+++ b/crates/kubelet/src/provider/mod.rs
@@ -169,7 +169,7 @@ pub trait Provider: Sized + Send + Sync + 'static {
         client: &kube::Client,
     ) -> HashMap<String, String> {
         let mut env = HashMap::new();
-        let vars = match container.env().as_ref() {
+        let vars = match container.env() {
             Some(e) => e,
             None => return env,
         };
@@ -231,7 +231,7 @@ pub async fn env_vars(
     client: &kube::Client,
 ) -> HashMap<String, String> {
     let mut env = HashMap::new();
-    let vars = match container.env().as_ref() {
+    let vars = match container.env() {
         Some(e) => e,
         None => return env,
     };

--- a/crates/kubelet/src/provider/mod.rs
+++ b/crates/kubelet/src/provider/mod.rs
@@ -169,8 +169,12 @@ pub trait Provider: Sized + Send + Sync + 'static {
         client: &kube::Client,
     ) -> HashMap<String, String> {
         let mut env = HashMap::new();
+        let vars = match container.env().as_ref() {
+            Some(e) => e,
+            None => return env,
+        };
 
-        for env_var in container.env().clone().into_iter() {
+        for env_var in vars.clone().into_iter() {
             let key = env_var.name;
             let value = match env_var.value {
                 Some(v) => v,
@@ -227,8 +231,12 @@ pub async fn env_vars(
     client: &kube::Client,
 ) -> HashMap<String, String> {
     let mut env = HashMap::new();
+    let vars = match container.env().as_ref() {
+        Some(e) => e,
+        None => return env,
+    };
 
-    for env_var in container.env().clone().into_iter() {
+    for env_var in vars.clone().into_iter() {
         let key = env_var.name;
         let value = match env_var.value {
             Some(v) => v,
@@ -268,7 +276,12 @@ async fn on_missing_env_value(
                 // I am not totally clear on what the outcome should
                 // be of a cfgmap key miss. So for now just return an
                 // empty default.
-                return cfgmap.data.get(&cfkey.key).cloned().unwrap_or_default();
+                return cfgmap
+                    .data
+                    .unwrap_or_default()
+                    .get(&cfkey.key)
+                    .cloned()
+                    .unwrap_or_default();
             }
             Err(e) => {
                 error!(error = %e, name, "Error fetching config map");
@@ -283,12 +296,13 @@ async fn on_missing_env_value(
             .get(name)
             .await
         {
-            Ok(mut secret) => {
+            Ok(secret) => {
                 // I am not totally clear on what the outcome should
                 // be of a secret key miss. So for now just return an
                 // empty default.
                 return secret
                     .data
+                    .unwrap_or_default()
                     .remove(&seckey.key)
                     .map(|s| String::from_utf8(s.0).unwrap_or_default())
                     .unwrap_or_default();

--- a/crates/kubelet/src/secret/mod.rs
+++ b/crates/kubelet/src/secret/mod.rs
@@ -54,10 +54,10 @@ impl RegistryAuthResolver {
 }
 
 fn parse_auth(secret: &Secret, registry_name: &str) -> Option<RegistryAuth> {
-    if secret.data.is_empty() {
-        None
+    if let Some(data) = secret.data.as_ref() {
+        parse_auth_from_secret_data(data, registry_name)
     } else {
-        parse_auth_from_secret_data(&secret.data, registry_name)
+        None
     }
 }
 

--- a/crates/kubelet/src/state/common/resources.rs
+++ b/crates/kubelet/src/state/common/resources.rs
@@ -51,13 +51,16 @@ impl<P: GenericProvider> State<P::PodState> for Resources<P> {
             let mut container_devices: PodResourceRequests = HashMap::new();
             for container in pod.all_containers() {
                 if let Some(resources) = container.resources() {
-                    let extended_resources: HashMap<String, Quantity> = resources
-                        .requests
-                        .iter()
-                        .filter(|(resource_name, _)| util::is_extended_resource_name(resource_name))
-                        .map(|(k, v)| (k.clone(), v.clone()))
-                        .collect();
-                    container_devices.insert(container.name().to_string(), extended_resources);
+                    if let Some(requests) = &resources.requests {
+                        let extended_resources: HashMap<String, Quantity> = requests
+                            .clone()
+                            .into_iter()
+                            .filter(|(resource_name, _)| {
+                                util::is_extended_resource_name(resource_name)
+                            })
+                            .collect();
+                        container_devices.insert(container.name().to_string(), extended_resources);
+                    }
                 }
             }
             // Do allocate for this Pod

--- a/crates/kubelet/src/volume/projected.rs
+++ b/crates/kubelet/src/volume/projected.rs
@@ -78,17 +78,18 @@ impl ProjectedVolume {
         })?;
         let mut volumes = Vec::new();
         let mut service_accounts = Vec::new();
-        for s in source
-            .sources
-            .iter()
-            .map(|proj| (client.clone(), proj))
-            .map(|(c, proj)| to_volume_ref(c, &pod, proj))
-            .collect::<anyhow::Result<Vec<Either<_, _>>>>()?
-            .into_iter()
-        {
-            match s {
-                Either::Left(v) => volumes.push(v),
-                Either::Right(sa) => service_accounts.push(sa),
+        if let Some(sources) = source.sources.as_ref() {
+            for s in sources
+                .iter()
+                .map(|proj| (client.clone(), proj))
+                .map(|(c, proj)| to_volume_ref(c, &pod, proj))
+                .collect::<anyhow::Result<Vec<Either<_, _>>>>()?
+                .into_iter()
+            {
+                match s {
+                    Either::Left(v) => volumes.push(v),
+                    Either::Right(sa) => service_accounts.push(sa),
+                }
             }
         }
         Ok(ProjectedVolume {

--- a/crates/kubelet/src/volume/secret.rs
+++ b/crates/kubelet/src/volume/secret.rs
@@ -11,7 +11,7 @@ pub struct SecretVolume {
     vol_name: String,
     sec_name: String,
     client: kube::Api<Secret>,
-    items: Vec<KeyToPath>,
+    items: Option<Vec<KeyToPath>>,
     mounted_path: Option<PathBuf>,
 }
 
@@ -65,6 +65,7 @@ impl SecretVolume {
 
         let data = secret.data;
         let data = data
+            .unwrap_or_default()
             .into_iter()
             .filter_map(
                 |(key, ByteString(data))| match mount_setting_for(&key, &self.items) {

--- a/crates/wasi-provider/Cargo.toml
+++ b/crates/wasi-provider/Cargo.toml
@@ -27,8 +27,8 @@ backtrace = "0.3"
 cap-std = "0.19"
 chrono = {version = "0.4", features = ["serde"]}
 futures = "0.3"
-krator = {version = "0.4", default-features = false}
-kube = {version = "0.58", default-features = false}
+krator = {version = "0.4", default-features = false, git = "https://github.com/thomastaylor312/krator", branch = "chore/k8s_openapi"}
+kube = {version = "0.60", default-features = false}
 kubelet = {path = "../kubelet", version = "1.0.0-alpha.1", default-features = false, features = ["derive"]}
 serde = "1.0"
 serde_derive = "1.0"
@@ -44,5 +44,5 @@ wat = "1.0.38"
 wasi-experimental-http-wasmtime = "0.6.0"
 
 [dev-dependencies]
-k8s-openapi = {version = "0.12", default-features = false, features = ["v1_21", "api"]}
+k8s-openapi = {version = "0.13", default-features = false, features = ["v1_22", "api"]}
 oci-distribution = {path = "../oci-distribution", version = "0.7"}

--- a/crates/wasi-provider/Cargo.toml
+++ b/crates/wasi-provider/Cargo.toml
@@ -27,7 +27,7 @@ backtrace = "0.3"
 cap-std = "0.19"
 chrono = {version = "0.4", features = ["serde"]}
 futures = "0.3"
-krator = {version = "0.4", default-features = false, git = "https://github.com/thomastaylor312/krator", branch = "chore/k8s_openapi"}
+krator = {version = "0.5", default-features = false}
 kube = {version = "0.60", default-features = false}
 kubelet = {path = "../kubelet", version = "1.0.0-alpha.1", default-features = false, features = ["derive"]}
 serde = "1.0"

--- a/crates/wasi-provider/src/states/container/waiting.rs
+++ b/crates/wasi-provider/src/states/container/waiting.rs
@@ -158,7 +158,7 @@ impl State<ContainerState> for Waiting {
 
         let mut env = kubelet::provider::env_vars(&container, &state.pod, &client).await;
         env.extend(container_envs);
-        let args = container.args().clone().unwrap_or_default();
+        let args: Vec<String> = container.args().map(|t| t.clone()).unwrap_or_default();
 
         // TODO: ~magic~ number
         let (tx, rx) = mpsc::channel(8);

--- a/crates/wasi-provider/src/states/container/waiting.rs
+++ b/crates/wasi-provider/src/states/container/waiting.rs
@@ -25,61 +25,61 @@ fn volume_path_map(
     container: &Container,
     volumes: &HashMap<String, VolumeRef>,
 ) -> anyhow::Result<HashMap<PathBuf, Option<PathBuf>>> {
-    // Check for volumes added during the `Resources` State that were not specified in original ContainerSpec
-    // Currently, these are only volumes required by device plugins.
-    let container_vol_names: Vec<String> = container
-        .volume_mounts()
-        .iter()
-        .cloned()
-        .map(|vm| vm.name)
-        .collect();
-    let mut resource_volumes: HashMap<PathBuf, Option<PathBuf>> = volumes
-        .iter()
-        .filter(|(k, _)| !container_vol_names.contains(k))
-        .map(|(k, v)| -> anyhow::Result<(PathBuf, Option<PathBuf>)> {
-            match v {
-                VolumeRef::DeviceVolume(host_path_vol, guest_path) => {
-                    let host_path = host_path_vol
-                        .get_path()
-                        .map(|p| p.to_owned())
-                        .ok_or_else(|| anyhow::anyhow!("Volume {} has not been mounted yet", k))?;
-                    Ok((host_path.clone(), Some(guest_path.to_owned())))
-                }
-                v_ref => Err(anyhow::anyhow!(
-                    "Volume mounted at path {:?} was not a DeviceVolume",
-                    v_ref.get_path()
-                )),
-            }
-        })
-        .collect::<anyhow::Result<HashMap<PathBuf, Option<PathBuf>>>>()?;
+    if let Some(volume_mounts) = container.volume_mounts().as_ref() {
+        // Check for volumes added during the `Resources` State that were not specified in original ContainerSpec
+        // Currently, these are only volumes required by device plugins.
+        let container_vol_names: Vec<String> =
+            volume_mounts.iter().cloned().map(|vm| vm.name).collect();
+        let mut resource_volumes: HashMap<PathBuf, Option<PathBuf>> =
+            volumes
+                .iter()
+                .filter(|(k, _)| !container_vol_names.contains(k))
+                .map(|(k, v)| -> anyhow::Result<(PathBuf, Option<PathBuf>)> {
+                    match v {
+                        VolumeRef::DeviceVolume(host_path_vol, guest_path) => {
+                            let host_path =
+                                host_path_vol.get_path().map(|p| p.to_owned()).ok_or_else(
+                                    || anyhow::anyhow!("Volume {} has not been mounted yet", k),
+                                )?;
+                            Ok((host_path, Some(guest_path.to_owned())))
+                        }
+                        v_ref => Err(anyhow::anyhow!(
+                            "Volume mounted at path {:?} was not a DeviceVolume",
+                            v_ref.get_path()
+                        )),
+                    }
+                })
+                .collect::<anyhow::Result<HashMap<PathBuf, Option<PathBuf>>>>()?;
 
-    resource_volumes.extend(
-        container
-            .volume_mounts()
-            .iter()
-            .map(|vm| -> anyhow::Result<(PathBuf, Option<PathBuf>)> {
-                // Check the volume exists first
-                let vol = volumes.get(&vm.name).ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "no volume with the name of {} found for container {}",
-                        vm.name,
-                        container.name()
-                    )
-                })?;
-                let host_path = vol.get_path().map(|p| p.to_owned()).ok_or_else(|| {
-                    anyhow::anyhow!("Volume {} has not been mounted yet", vm.name)
-                })?;
-                let mut guest_path = PathBuf::from(&vm.mount_path);
-                if let Some(sub_path) = &vm.sub_path {
-                    guest_path.push(sub_path);
-                }
-                // We can safely assume that this should be valid UTF-8 because it would have
-                // been validated by the k8s API
-                Ok((host_path, Some(guest_path)))
-            })
-            .collect::<anyhow::Result<HashMap<PathBuf, Option<PathBuf>>>>()?,
-    );
-    Ok(resource_volumes)
+        resource_volumes.extend(
+            volume_mounts
+                .iter()
+                .map(|vm| -> anyhow::Result<(PathBuf, Option<PathBuf>)> {
+                    // Check the volume exists first
+                    let vol = volumes.get(&vm.name).ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "no volume with the name of {} found for container {}",
+                            vm.name,
+                            container.name()
+                        )
+                    })?;
+                    let host_path = vol.get_path().map(|p| p.to_owned()).ok_or_else(|| {
+                        anyhow::anyhow!("Volume {} has not been mounted yet", vm.name)
+                    })?;
+                    let mut guest_path = PathBuf::from(&vm.mount_path);
+                    if let Some(sub_path) = &vm.sub_path {
+                        guest_path.push(sub_path);
+                    }
+                    // We can safely assume that this should be valid UTF-8 because it would have
+                    // been validated by the k8s API
+                    Ok((host_path, Some(guest_path)))
+                })
+                .collect::<anyhow::Result<HashMap<PathBuf, Option<PathBuf>>>>()?,
+        );
+        Ok(resource_volumes)
+    } else {
+        Ok(HashMap::default())
+    }
 }
 
 /// The container is starting.
@@ -158,7 +158,7 @@ impl State<ContainerState> for Waiting {
 
         let mut env = kubelet::provider::env_vars(&container, &state.pod, &client).await;
         env.extend(container_envs);
-        let args = container.args().clone();
+        let args = container.args().clone().unwrap_or_default();
 
         // TODO: ~magic~ number
         let (tx, rx) = mpsc::channel(8);
@@ -305,7 +305,7 @@ mod tests {
         };
         let container = Container::new(&KubeContainer {
             name: "foo".to_string(),
-            volume_mounts: vec![volume],
+            volume_mounts: Some(vec![volume]),
             ..Default::default()
         });
         let host_path2 = "/host/path/2";

--- a/tests/assert.rs
+++ b/tests/assert.rs
@@ -55,7 +55,7 @@ pub async fn pod_exited_successfully(pods: &Api<Pod>, pod_name: &str) -> anyhow:
     let pod = pods.get(pod_name).await?;
 
     let state = (|| {
-        pod.status?.container_statuses[0]
+        pod.status?.container_statuses?[0]
             .state
             .as_ref()?
             .terminated
@@ -104,7 +104,7 @@ pub async fn main_container_exited_with_failure(
     let pod = pods.get(pod_name).await?;
 
     let state = (|| {
-        pod.status?.container_statuses[0]
+        pod.status?.container_statuses?[0]
             .state
             .as_ref()?
             .terminated

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -44,12 +44,17 @@ async fn verify_wasi_node(node: Node) {
     assert_eq!(
         node_meta
             .labels
+            .expect("node had no labels")
             .get("kubernetes.io/arch")
             .expect("node did not have kubernetes.io/arch label"),
         "wasm32-wasi"
     );
 
-    let taints = node.spec.expect("node had no spec").taints;
+    let taints = node
+        .spec
+        .expect("node had no spec")
+        .taints
+        .expect("node had no taints");
     let taint = taints
         .iter()
         .find(|t| (t.key == "kubernetes.io/arch") & (t.effect == "NoExecute"))
@@ -1065,8 +1070,8 @@ async fn create_device_plugin_resource_pod(
     let mut requests = std::collections::BTreeMap::new();
     requests.insert(RESOURCE_NAME.to_string(), Quantity("1".to_string()));
     let resources = ResourceRequirements {
-        limits: requests.clone(),
-        requests: requests,
+        limits: Some(requests.clone()),
+        requests: Some(requests),
     };
 
     wasmercise_wasi(


### PR DESCRIPTION
As k8s-openapi reverted in https://github.com/Arnavion/k8s-openapi/commit/f0fda041e401e7d3bbb39b19ff305e258688728d to its use of `Option<>`, this commit reverts most of 4846df7982fe4649e2e038ed7f69b04f148063c0.

Also update kube and kube-runtime to 0.60.

**Note:** This depends on krator PR: https://github.com/krator-rs/krator/pull/49 so we must wait for this PR to be merged and a krator release done.

Fixes #660
