### PR TITLE
OCI Distribution Improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,6 +541,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "ct-logs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,6 +1018,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac",
+ "digest",
+]
+
+[[package]]
 name = "hostname"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,6 +1335,21 @@ dependencies = [
  "log 0.4.14",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "jwt"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98328bb4f360e6b2ceb1f95645602c7014000ef0c3809963df8ad3a3a09f8d99"
+dependencies = [
+ "base64 0.13.0",
+ "crypto-mac",
+ "digest",
+ "hmac",
+ "serde",
+ "serde_json",
+ "sha2",
 ]
 
 [[package]]
@@ -1897,6 +1932,7 @@ dependencies = [
  "anyhow",
  "futures-util",
  "hyperx",
+ "jwt",
  "lazy_static",
  "regex",
  "reqwest",
@@ -2944,6 +2980,12 @@ dependencies = [
  "quote 1.0.9",
  "syn 1.0.74",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"

--- a/crates/oci-distribution/Cargo.toml
+++ b/crates/oci-distribution/Cargo.toml
@@ -42,6 +42,7 @@ sha2 = "0.9.2"
 tokio = {version = "1.0", features = ["macros", "fs"]}
 tracing = {version = "0.1", features = ['log']}
 www-authenticate = "0.3"
+jwt = "0.15"
 
 [dev-dependencies]
 rstest = "0.11"

--- a/crates/oci-distribution/src/lib.rs
+++ b/crates/oci-distribution/src/lib.rs
@@ -7,6 +7,7 @@ pub mod manifest;
 mod reference;
 mod regexp;
 pub mod secrets;
+mod token_cache;
 
 #[doc(inline)]
 pub use client::Client;

--- a/crates/oci-distribution/src/reference.rs
+++ b/crates/oci-distribution/src/reference.rs
@@ -76,6 +76,18 @@ pub struct Reference {
 }
 
 impl Reference {
+    /// Resolve the registry address of a given `Reference`.
+    ///
+    /// Some registries, such as docker.io, uses a different address for the actual
+    /// registry. This function implements such redirection.
+    pub fn resolve_registry(&self) -> &str {
+        let registry = self.registry();
+        match registry {
+            "docker.io" => "registry-1.docker.io".into(),
+            _ => registry.into(),
+        }
+    }
+
     /// registry returns the name of the registry.
     pub fn registry(&self) -> &str {
         &self.registry

--- a/crates/oci-distribution/src/secrets.rs
+++ b/crates/oci-distribution/src/secrets.rs
@@ -8,14 +8,6 @@ pub enum RegistryAuth {
     Basic(String, String),
 }
 
-/// Desired operation for registry authentication
-pub enum RegistryOperation {
-    /// Authenticate for push operations
-    Push,
-    /// Authenticate for pull operations
-    Pull,
-}
-
 pub(crate) trait Authenticable {
     fn apply_authentication(self, auth: &RegistryAuth) -> Self;
 }

--- a/crates/oci-distribution/src/token_cache.rs
+++ b/crates/oci-distribution/src/token_cache.rs
@@ -1,0 +1,74 @@
+use crate::reference::Reference;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+/// A token granted during the OAuth2-like workflow for OCI registries.
+#[derive(Deserialize)]
+#[serde(untagged)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RegistryToken {
+    Token { token: String },
+    AccessToken { access_token: String },
+}
+
+pub(crate) enum RegistryTokenType {
+    Bearer(RegistryToken),
+    Basic(String, String),
+}
+
+impl RegistryToken {
+    pub fn bearer_token(&self) -> String {
+        format!("Bearer {}", self.token())
+    }
+
+    pub fn token(&self) -> &str {
+        match self {
+            RegistryToken::Token { token } => token,
+            RegistryToken::AccessToken { access_token } => access_token,
+        }
+    }
+}
+
+/// Desired operation for registry authentication
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RegistryOperation {
+    /// Authenticate for push operations
+    Push,
+    /// Authenticate for pull operations
+    Pull,
+}
+
+#[derive(Default)]
+pub(crate) struct TokenCache {
+    // (registry, repository, scope) -> (token, expiration)
+    tokens: BTreeMap<(String, String, RegistryOperation), (RegistryTokenType, usize)>,
+}
+
+impl TokenCache {
+    pub(crate) fn new() -> Self {
+        TokenCache {
+            tokens: BTreeMap::new(),
+        }
+    }
+
+    pub(crate) fn insert(
+        &mut self,
+        reference: &Reference,
+        op: RegistryOperation,
+        token: RegistryTokenType,
+    ) {
+        todo!()
+    }
+
+    pub(crate) fn get(
+        &self,
+        reference: &Reference,
+        op: RegistryOperation,
+    ) -> Option<RegistryTokenType> {
+        todo!()
+    }
+
+    pub(crate) fn contains_key(&self, reference: &Reference, op: RegistryOperation) -> bool {
+        todo!()
+    }
+}


### PR DESCRIPTION
This PR includes a number of improvements for OCI distribution:

* HEAD requests are attempted for fetching manifest digest, with a fallback to GET (some providers to do not include the digest in the HEAD response). This appears to be preferred by registry providers such as DockerHub, because they do not apply rate limits to HEAD requests. I have confirmed that `fetch_manifest_digest`, including any authentication API calls, does not incur ratelimits. 
* JWT tokens are now cached by (registry, repository, operation), instead of just registry. Previously, requests using the same client to perform different operations, or access different repositories in the same registry would fail, because tokens are scoped to the repository. 
* Tokens are now stored in an expiring cache, which inspects the JWT for its expiration timestamp, and returns `None` if a token is in the cache but is expired. 

Combined, these changes should make it possible to reuse the OCI client over long periods of time, with more efficient registry API usage. 