### PR TITLE
Modify 'std::u64::MAX' to 'u64::MAX'

### DIFF
--- a/crates/kubelet/src/kubelet.rs
+++ b/crates/kubelet/src/kubelet.rs
@@ -188,7 +188,7 @@ async fn start_plugin_registry(registrar: Option<Arc<PluginRegistry>>) -> anyhow
             task::spawn(async {
                 loop {
                     // We run a delay here so we don't waste time on NOOP CPU cycles
-                    tokio::time::sleep(tokio::time::Duration::from_secs(std::u64::MAX)).await;
+                    tokio::time::sleep(tokio::time::Duration::from_secs(u64::MAX)).await;
                 }
             })
             .map_err(anyhow::Error::from)
@@ -206,7 +206,7 @@ async fn start_device_manager(device_manager: Option<Arc<DeviceManager>>) -> any
             task::spawn(async {
                 loop {
                     // We run a delay here so we don't waste time on NOOP CPU cycles
-                    tokio::time::sleep(tokio::time::Duration::from_secs(std::u64::MAX)).await;
+                    tokio::time::sleep(tokio::time::Duration::from_secs(u64::MAX)).await;
                 }
             })
             .map_err(anyhow::Error::from)

--- a/tests/device_plugin/mod.rs
+++ b/tests/device_plugin/mod.rs
@@ -52,7 +52,7 @@ impl DevicePlugin for MockDevicePlugin {
                 .unwrap();
             loop {
                 // ListAndWatch should not end
-                tokio::time::sleep(tokio::time::Duration::from_secs(std::u64::MAX)).await;
+                tokio::time::sleep(tokio::time::Duration::from_secs(u64::MAX)).await;
             }
         });
         Ok(Response::new(Box::pin(


### PR DESCRIPTION
'u64::MAX' is the recommended way to represent the largest number of u64 type(reference: https://doc.rust-lang.org/std/u64/constant.MAX.html) and 'std::u64::MAX' is now deprecated in a future Rust version.

Signed-off-by: zyy17 <zyylsxm@gmail.com>