### PR TITLE
Migrated from k8s.gcr.io to registry.k8s.io in lib.rs

### DIFF
--- a/crates/wasi-provider/src/lib.rs
+++ b/crates/wasi-provider/src/lib.rs
@@ -219,7 +219,7 @@ impl GenericProvider for WasiProvider {
         container: &kubelet::container::Container,
     ) -> anyhow::Result<()> {
         if let Some(image) = container.image()? {
-            if image.whole().starts_with("k8s.gcr.io/kube-proxy") {
+            if image.whole().starts_with("registry.k8s.io/kube-proxy") {
                 return Err(anyhow::anyhow!("Cannot run kube-proxy"));
             }
         }


### PR DESCRIPTION
This issues fixes:
[Umbrella Issue] Migrate CNCF Ecosystem projects from k8s.gcr.io to registry.k8s.io
https://github.com/kubernetes/k8s.io/issues/4780